### PR TITLE
Fix UUID to only return Middle Endian on SMBIOS Versions >= 2.6

### DIFF
--- a/smbios/smbios.go
+++ b/smbios/smbios.go
@@ -14,7 +14,11 @@ import (
 
 // SMBIOS represents the Sysytem Management BIOS.
 type SMBIOS struct {
-	Version    string
+	Version struct {
+		Major    int
+		Minor    int
+		Revision int
+	}
 	Structures []*smbios.Structure
 
 	BIOSInformationStructure            BIOSInformationStructure
@@ -47,8 +51,7 @@ func New() (*SMBIOS, error) {
 
 	s := &SMBIOS{}
 
-	major, minor, rev := ep.Version()
-	s.Version = fmt.Sprintf("%d.%d.%d", major, minor, rev)
+	s.Version.Major, s.Version.Minor, s.Version.Revision = ep.Version()
 
 	d := smbios.NewDecoder(rc)
 


### PR DESCRIPTION
Fix to the UUID function to only convert to Middle Endian on SMBIOS Versions greater than or equal to 2.6.

I've also published patched copies of Sidero and Talos using this branch:
https://github.com/bnason/talos/tree/go-smbios-uuid-fix
https://github.com/bnason/sidero/tree/go-smbios-uuid-fix

I was able to successfully test this on 3 systems:
1) Using a VirtualBox VM with SMBIOS Version 2.5
2) Using a desktop pc with a SMBIOS Version 2.7
3) Using a very old server with a SMBIOS Version 2.5

One interesting thing to note about system 2 is that before pxe booting, the system prints the UUID as 9402DE03-8004-0605-F806-D50700080009 while both iPXE and go-smbios report it as 03DE0294-0480-0506-F806-D50700080009.

More systems should probably be tested to ensure wide compatability.